### PR TITLE
reworking-registration-endpoint

### DIFF
--- a/kirby/models.py
+++ b/kirby/models.py
@@ -9,6 +9,9 @@ class Environment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(), nullable=False, unique=True)
 
+    def __repr__(self):
+        return f"<Environment name={self.name}>"
+
 
 class JobType(Enum):
     SCHEDULED = "scheduled"
@@ -29,6 +32,9 @@ class Job(db.Model):
         notification.groups.append(group)
         self.notifications.append(notification)
 
+    def __repr__(self):
+        return f"<Job name={self.name} type={self.type.value}>"
+
 
 schedules_to_contexts = db.Table(
     "schedules_to_contexts",
@@ -41,14 +47,14 @@ schedules_to_contexts = db.Table(
 class Context(db.Model):
     id = db.Column(db.Integer, primary_key=True)
 
-    environment_name = db.Column(
-        db.Integer, db.ForeignKey("environment.name"), nullable=False
+    environment_id = db.Column(
+        db.Integer, db.ForeignKey("environment.id"), nullable=False
     )
     environment = db.relationship(
         Environment, backref=db.backref("contexts", lazy=True)
     )
 
-    job_name = db.Column(db.Integer, db.ForeignKey("job.name"))
+    job_id = db.Column(db.Integer, db.ForeignKey("job.id"))
     job = db.relationship(Job, backref=db.backref("contexts", lazy=True))
 
     schedules = db.relationship(
@@ -62,6 +68,9 @@ class Context(db.Model):
 
     def add_schedule(self, schedule):
         self.schedules.append(schedule)
+
+    def __repr__(self):
+        return f"<Context job={self.job} environment={self.environment}>"
 
 
 class ConfigKey(db.Model):
@@ -158,7 +167,7 @@ class Notification(db.Model):
     on_retry = db.Column(db.Boolean, nullable=False, default=False)
     on_failure = db.Column(db.Boolean, nullable=False, default=True)
 
-    job_name = db.Column(db.Integer, db.ForeignKey("job.name"), nullable=False)
+    job_id = db.Column(db.Integer, db.ForeignKey("job.id"), nullable=False)
     job = db.relationship(Job, backref=db.backref("notifications", lazy=True))
 
     groups = db.relationship(
@@ -190,6 +199,9 @@ class Script(db.Model):
     def add_destination(self, destination):
         self.destinations.append(destination)
 
+    def __repr__(self):
+        return f"<Script name={self.package_name} package_version={self.package_version}>"
+
 
 class Topic(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -208,3 +220,6 @@ class Topic(db.Model):
         backref=db.backref("destinations", lazy=True),
         foreign_keys=[provider_id],
     )
+
+    def __repr__(self):
+        return f"<Topic name={self.name}>"

--- a/kirby/web/admin.py
+++ b/kirby/web/admin.py
@@ -12,6 +12,8 @@ from ..models import (
     NotificationEmail,
     NotificationGroup,
     Notification,
+    Script,
+    Topic,
 )
 
 admin = Admin(template_mode="bootstrap3")
@@ -26,6 +28,8 @@ models = (
     NotificationEmail,
     NotificationGroup,
     Notification,
+    Script,
+    Topic,
 )
 
 

--- a/kirby/web/endpoints.py
+++ b/kirby/web/endpoints.py
@@ -41,7 +41,8 @@ class Registration(Resource):
             return {"message": "Sucess"}
         except NoResultFound:
             abort(
-                400, "One or many of the id given refer to inexistent objects."
+                400,
+                "One or many of the given 'id' refer to inexistent objects.",
             )
 
 

--- a/kirby/web/endpoints.py
+++ b/kirby/web/endpoints.py
@@ -1,37 +1,58 @@
-import sqlalchemy
+from sqlalchemy import func
+from sqlalchemy.orm.exc import NoResultFound
 from flask import abort
+from datetime import datetime
 from flask_restplus import Api, Resource, reqparse
-from ..models import db, Job, JobType
+from ..models import db, Script, Topic
 
 api = Api()
 
 registration_parser = reqparse.RequestParser()
-registration_parser.add_argument("name", type=str, required=True)
-registration_parser.add_argument("description", type=str)
-registration_parser.add_argument(
-    "type", choices=["scheduled", "triggered"], required=True
-)
+registration_parser.add_argument("script_id", type=int)
+registration_parser.add_argument("source_id", type=int, action="append")
+registration_parser.add_argument("destination_id", type=int, action="append")
 
 
 @api.route("/registration")
 class Registration(Resource):
     @api.expect(registration_parser)
-    def post(self):
+    def patch(self):
         args = registration_parser.parse_args()
+
         try:
-            db.session.add(
-                Job(
-                    name=args["name"],
-                    description=args.get("description"),
-                    type=JobType(args["type"]),
-                )
+            # Update last_seen
+            script = (
+                db.session.query(Script).filter_by(id=args["script_id"]).one()
             )
+            script.last_seen = datetime.utcnow()
+
+            # Add sources and destinations
+            for source_id in args["source_id"]:
+                source = db.session.query(Topic).filter_by(id=source_id).one()
+                script.add_source(source)
+            for destination_id in args["destination_id"]:
+                destination = (
+                    db.session.query(Topic).filter_by(id=destination_id).one()
+                )
+                script.add_destination(destination)
+
             db.session.commit()
-            return {
-                "id": db.session.query(Job)
-                .filter_by(name=args["name"])
-                .one()
-                .id
-            }
-        except sqlalchemy.exc.IntegrityError:
-            abort(400, "There is already a Job with this name.")
+
+            return {"message": "Sucess"}
+        except NoResultFound:
+            abort(
+                400, "One or many of the id given refer to inexistent objects."
+            )
+
+
+topic_parser = reqparse.RequestParser()
+topic_parser.add_argument("name", type=str, required=True)
+
+
+@api.route("/topic")
+class TopicView(Resource):
+    @api.expect(topic_parser)
+    def get(self):
+        args = topic_parser.parse_args()
+        topic = db.session.query(Topic).filter_by(name=args["name"]).one()
+        return {"id": topic.id, "name": topic.name}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+from pytest import fixture
+from datetime import datetime
+from requests_flask_adapter import Session
+
+from kirby.web import app_maker
+from kirby.models import db, Environment, Job, Context, Script, Topic
+
+API_ROOT = "http://some-test-server.somewhere"
+
+
+@fixture(scope="function")
+def webapp():
+    app = app_maker(
+        config={
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite://",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+
+
+@fixture
+def session(webapp):
+    Session.register(API_ROOT, webapp)
+    return Session()
+
+
+@fixture
+def db_env_factory():
+    def _make_env(env_name):
+        env = Environment(name=env_name)
+        db.session.add(env)
+        db.session.commit()
+        return env
+
+    yield _make_env
+
+
+@fixture
+def db_job_factory():
+    def _make_job(job_name, job_type):
+        job = Job(
+            name=job_name,
+            description=f"This job is named {job_name}.",
+            type=job_type,
+        )
+        db.session.add(job)
+        db.session.commit()
+        return job
+
+    yield _make_job
+
+
+@fixture
+def db_context_factory():
+    def _make_context(env, job):
+        context = Context(environment=env, job=job)
+        db.session.add(context)
+        db.session.commit()
+        return context
+
+    yield _make_context
+
+
+@fixture
+def db_script_factory():
+    def _make_script(package_name, package_version, context):
+        script = Script(
+            package_name=package_name,
+            package_version=package_version,
+            context=context,
+            first_seen=datetime.utcnow(),
+        )
+        db.session.add(script)
+        db.session.commit()
+        return script
+
+    yield _make_script
+
+
+@fixture
+def db_topic_factory():
+    def _make_topic(topic_name):
+        topic = Topic(name=topic_name)
+        db.session.add(topic)
+        db.session.commit()
+        return topic
+
+    yield _make_topic

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,24 +1,84 @@
 from requests_flask_adapter import Session
-from kirby.web import app_maker
 from pytest import fixture
+from datetime import datetime
+
+from kirby.web import app_maker
+from kirby.models import db, Environment, Job, JobType, Context, Script, Topic
 
 BASE_API = "http://some-test-server.somewhere"
 
 
+@fixture(scope="function")
+def webapp():
+    config = {
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite://",
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+    }
+    app = app_maker(config=config)
+    with app.app_context():
+        db.create_all()
+        yield app
+
+
 @fixture
-def session():
-    app = app_maker()
-    Session.register(BASE_API, app)
+def session(webapp):
+    Session.register(BASE_API, webapp)
     return Session()
 
 
-def test_it_register_a_job(session):
-    result = session.post(
+@fixture
+def db_populated():
+    env = Environment(name="test")
+    job = Job(
+        name="Booking",
+        description="This is a process for booking orders.",
+        type=JobType.TRIGGERED,
+    )
+    context = Context(environment=env, job=job)
+    script = Script(
+        package_name="booking_process",
+        package_version="1.0.1",
+        context=context,
+        first_seen=datetime.utcnow(),
+    )
+    orders_topic = Topic(name="Orders")
+    asset_management_topic = Topic(name="AssetManagement")
+
+    db.session.add_all(
+        [env, job, context, script, orders_topic, asset_management_topic]
+    )
+    db.session.commit()
+
+
+def get_id_topic(session, name):
+    return session.get(
+        "/".join([BASE_API, "topic"]), params={"name": name}
+    ).json()["id"]
+
+
+def test_if_get_id_topic(session, db_populated):
+    assert get_id_topic(session, "Orders") == 1
+
+
+def test_it_register_a_script(session, db_populated):
+    id_source = get_id_topic(session, "Orders")
+    id_destination = get_id_topic(session, "AssetManagement")
+
+    result = session.patch(
         "/".join([BASE_API, "registration"]),
         params={
-            "name": "Test Scheduled",
-            "description": "This is a test job.",
-            "type": "scheduled",
+            "script_id": 1,
+            "source_id": id_source,
+            "destination_id": id_destination,
         },
     )
     assert result.status_code == 200
+
+    script_registered = (
+        db.session.query(Script)
+        .filter_by(package_name="booking_process")
+        .one()
+    )
+    assert script_registered.sources[0].id == id_source
+    assert script_registered.destinations[0].id == id_destination

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -3,16 +3,16 @@ from kirby.models import db, JobType, Script
 from tests.conftest import API_ROOT
 
 
-def get_id_topic(session, name):
+def get_topic_id(session, name):
     return session.get(
         "/".join([API_ROOT, "topic"]), params={"name": name}
     ).json()["id"]
 
 
-def test_if_get_id_topic(session, db_topic_factory):
+def test_if_get_topic_id(session, db_topic_factory):
     topic_name = "Orders"
     db_topic_factory(topic_name)
-    assert get_id_topic(session, topic_name) == 1
+    assert get_topic_id(session, topic_name) == 1
 
 
 def test_it_register_a_script(
@@ -38,8 +38,8 @@ def test_it_register_a_script(
     db_topic_factory(asset_management_topic_name)
 
     # Get id registered
-    id_source = get_id_topic(session, orders_topic_name)
-    id_destination = get_id_topic(session, asset_management_topic_name)
+    id_source = get_topic_id(session, orders_topic_name)
+    id_destination = get_topic_id(session, asset_management_topic_name)
 
     result = session.patch(
         "/".join([API_ROOT, "registration"]),

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,72 +1,48 @@
-from requests_flask_adapter import Session
-from pytest import fixture
-from datetime import datetime
+from kirby.models import db, JobType, Script
 
-from kirby.web import app_maker
-from kirby.models import db, Environment, Job, JobType, Context, Script, Topic
-
-BASE_API = "http://some-test-server.somewhere"
-
-
-@fixture(scope="function")
-def webapp():
-    config = {
-        "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": "sqlite://",
-        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-    }
-    app = app_maker(config=config)
-    with app.app_context():
-        db.create_all()
-        yield app
-
-
-@fixture
-def session(webapp):
-    Session.register(BASE_API, webapp)
-    return Session()
-
-
-@fixture
-def db_populated():
-    env = Environment(name="test")
-    job = Job(
-        name="Booking",
-        description="This is a process for booking orders.",
-        type=JobType.TRIGGERED,
-    )
-    context = Context(environment=env, job=job)
-    script = Script(
-        package_name="booking_process",
-        package_version="1.0.1",
-        context=context,
-        first_seen=datetime.utcnow(),
-    )
-    orders_topic = Topic(name="Orders")
-    asset_management_topic = Topic(name="AssetManagement")
-
-    db.session.add_all(
-        [env, job, context, script, orders_topic, asset_management_topic]
-    )
-    db.session.commit()
+from tests.conftest import API_ROOT
 
 
 def get_id_topic(session, name):
     return session.get(
-        "/".join([BASE_API, "topic"]), params={"name": name}
+        "/".join([API_ROOT, "topic"]), params={"name": name}
     ).json()["id"]
 
 
-def test_if_get_id_topic(session, db_populated):
-    assert get_id_topic(session, "Orders") == 1
+def test_if_get_id_topic(session, db_topic_factory):
+    topic_name = "Orders"
+    db_topic_factory(topic_name)
+    assert get_id_topic(session, topic_name) == 1
 
 
-def test_it_register_a_script(session, db_populated):
-    id_source = get_id_topic(session, "Orders")
-    id_destination = get_id_topic(session, "AssetManagement")
+def test_it_register_a_script(
+    session,
+    db_env_factory,
+    db_job_factory,
+    db_context_factory,
+    db_script_factory,
+    db_topic_factory,
+):
+    # Init variables to describe script env
+    package_name = "booking_process"
+    package_version = "1.0.1"
+    orders_topic_name = "Orders"
+    asset_management_topic_name = "AssetManagement"
+
+    # Populate database
+    env = db_env_factory("test")
+    job = db_job_factory("Booking", JobType.TRIGGERED)
+    context = db_context_factory(env, job)
+    db_script_factory(package_name, package_version, context)
+    db_topic_factory(orders_topic_name)
+    db_topic_factory(asset_management_topic_name)
+
+    # Get id registered
+    id_source = get_id_topic(session, orders_topic_name)
+    id_destination = get_id_topic(session, asset_management_topic_name)
 
     result = session.patch(
-        "/".join([BASE_API, "registration"]),
+        "/".join([API_ROOT, "registration"]),
         params={
             "script_id": 1,
             "source_id": id_source,
@@ -76,9 +52,7 @@ def test_it_register_a_script(session, db_populated):
     assert result.status_code == 200
 
     script_registered = (
-        db.session.query(Script)
-        .filter_by(package_name="booking_process")
-        .one()
+        db.session.query(Script).filter_by(package_name=package_name).one()
     )
     assert script_registered.sources[0].id == id_source
     assert script_registered.destinations[0].id == id_destination

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,3 @@
-import pytest
 from datetime import datetime
 from dateutil.parser import parse
 from kirby.models import (
@@ -13,20 +12,6 @@ from kirby.models import (
     Script,
     Topic,
 )
-from kirby.web import app_maker
-
-
-@pytest.fixture(scope="function")
-def webapp():
-    config = {
-        "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": "sqlite://",
-        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-    }
-    app = app_maker(config=config)
-    with app.app_context():
-        db.create_all()
-        yield app
 
 
 def test_it_creates_a_job(webapp):


### PR DESCRIPTION
Adapt registration endpoint to the new model: now register a Script and not a Job anymore.  
Also resolving models errors: set external_keys to the real primary_keys.  
Adding representation of rows of the model for readibility on the admin plateform.