### PR TITLE
Making 'api.queue.Queue' inherit from 'api.ext.Topic'

### DIFF
--- a/kirby/api/__init__.py
+++ b/kirby/api/__init__.py
@@ -60,11 +60,11 @@ class Kirby:
                 raise ClientError("There is an error with the id(s) given.")
 
     def add_source(self, source):
-        self._register(source_id=self.get_topic_id(source.topic_name))
+        self._register(source_id=self.get_topic_id(source.name))
 
     def add_destination(self, destination):
         self._register(
-            destination_id=self.get_topic_id(destination.topic_name)
+            destination_id=self.get_topic_id(destination.name)
         )
 
 

--- a/kirby/api/ext.py
+++ b/kirby/api/ext.py
@@ -143,3 +143,9 @@ class Topic:
         if not self.testing:
             self._producer.close()
             self._consumer.close(autocommit=False)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/kirby/api/ext.py
+++ b/kirby/api/ext.py
@@ -1,61 +1,145 @@
+import logging
+import datetime
 import msgpack
 from kafka import KafkaConsumer, KafkaProducer
+from kafka.errors import NoBrokersAvailable
+
+logger = logging.getLogger(__name__)
+
+
+def retry(function):
+
+    NB_RETRY = 3
+
+    def function_decorated():
+        for counter in range(NB_RETRY):
+            try:
+                return_value = function_decorated()
+            except NoBrokersAvailable as e:
+                if counter == NB_RETRY:
+                    logger.error(
+                        f"The function {function.__name__} was "
+                        f"launched {counter + 1} times without success."
+                    )
+                    raise e
+            else:
+                logger.info(
+                    f"The function {function.__name__} was "
+                    f"launched {counter + 1} times and succeed."
+                )
+                return return_value
+
+    return function
 
 
 class Topic:
     def __init__(
-        self, kirby_app, topic_name_variable_name, security_protocol="SSL"
+        self,
+        kirby_app,
+        topic_name_variable_name,
+        security_protocol="SSL",
+        testing=False,
     ):
-        self.topic_name = kirby_app.ctx[topic_name_variable_name]
+        self.name = kirby_app.ctx[topic_name_variable_name]
+        self.testing = testing
+        mode = "testing" if self.testing else "live"
+        logger.debug(f"starting topic {self.name} in {mode} mode")
+        self.init_kafka(kirby_app, security_protocol)
+
+    @retry
+    def init_kafka(self, kirby_app, security_protocol):
         self._args = {
-            "bootstrap_servers": kirby_app.ctx.KAFKA_BOOTSTRAP_SERVERS,
-            "client_id": kirby_app.ctx.PACKAGE_NAME,
+            "bootstrap_servers": kirby_app.ctx.KAFKA_BOOTSTRAP_SERVERS
         }
 
         if security_protocol:
             self._args.update(
                 {
-                    "ssl_cafile": kirby_app.ctx.SSL_CAFILE,
-                    "ssl_certfile": kirby_app.ctx.SSL_CERTFILE,
-                    "ssl_keyfile": kirby_app.ctx.SSL_KEYFILE,
+                    "ssl_cafile": kirby_app.ctx.KAFKA_SSL_CAFILE,
+                    "ssl_certfile": kirby_app.ctx.KAFKA_SSL_CERTFILE,
+                    "ssl_keyfile": kirby_app.ctx.KAFKA_SSL_KEYFILE,
                     "security_protocol": "SSL",
                 }
             )
+        if self.testing:
+            self._messages = []
+            self.cursor_position = 0
+        else:
+            self._consumer = KafkaConsumer(
+                self.name,
+                group_id=kirby_app.ctx.PACKAGE_NAME,
+                value_deserializer=lambda x: msgpack.loads(x, raw=False),
+                **self._args,
+            )
+            self._producer = KafkaProducer(
+                value_serializer=msgpack.dumps, **self._args
+            )
 
-        self.consumer = KafkaConsumer(
-            group_id=kirby_app.ctx.PACKAGE_NAME, **self._args
-        )
-        self._subscribe_to_topic(self.topic_name)
+    @retry
+    def send(self, message, submitted=None):
+        if submitted is None:
+            submitted = datetime.datetime.utcnow()
 
-    @property
-    def producer(self):
-        if not hasattr(self, "_producer"):
-            self._producer = KafkaProducer(**self._args)
-        return self._producer
+        if self.testing:
+            self._messages.append((submitted, message))
 
-    def _subscribe_to_topic(self, topic_name):
-        self.consumer.subscribe([topic_name])
-        self.consumer.poll()
-        # We poll here to allow the consumer to have a partition assigned
+        else:
+            timestamp_ms = int(submitted.timestamp() * 1000)
+            self._producer.send(
+                self.name, value=message, timestamp_ms=timestamp_ms
+            )
+            self._producer.flush()
 
-    def send(self, item):
-        message = msgpack.packb(item)
-        self.producer.send(self.topic_name, value=message)
-        self.producer.flush()
+    def between(self, start, end):
+        if self.testing:
+            return [msg for t, msg in self._messages if start <= t < end]
+        else:
+            self._consumer.poll(timeout_ms=5000)
+
+            partitions = self._consumer.assignment()
+
+            start_mapping = {p: start.timestamp() for p in partitions}
+            start_offsets = self._consumer.offsets_for_times(start_mapping)
+
+            start_timestamp = start.timestamp() * 1000
+            end_timestamp = end.timestamp() * 1000
+
+            messages = []
+            for partition, offsets in start_offsets.items():
+                self._consumer.seek(partition=partition, offset=offsets.offset)
+
+            records_by_partition = self._consumer.poll(timeout_ms=5000)
+
+            for partition, records in records_by_partition.items():
+                for record in records:
+                    if start_timestamp <= record.timestamp < end_timestamp:
+                        messages.append((record.timestamp, record.value))
+
+            messages.sort(key=lambda x: x[0])
+            return [v for t, v in messages]
 
     @staticmethod
     def message_to_item(raw_message):
         if raw_message:
-            for nested_message in raw_message.values():
-                for message in nested_message:
-                    return msgpack.unpackb(message.value, raw=False)
+            for messages_by_topic in raw_message.values():
+                for message in messages_by_topic:
+                    return message.value
 
+    @retry
     def next(self, timeout_ms=500):
-        message = self.consumer.poll(max_records=1, timeout_ms=timeout_ms)
-        self.consumer.commit()
-        return Topic.message_to_item(message)
+        if not self.testing:
+            message = self._consumer.poll(max_records=1, timeout_ms=timeout_ms)
+            self._consumer.commit()
+            return self.message_to_item(message)
+        else:
+            if self._messages:
+                (_, message) = self._messages[self.cursor_position]
+                self.cursor_position += 1
+                return message
+            else:
+                return None
 
     def close(self):
-        if hasattr(self, "_producer"):
+        if not self.testing:
             self._producer.close()
-        self.consumer.close(autocommit=False)
+            self._consumer.close(autocommit=False)

--- a/kirby/api/queue.py
+++ b/kirby/api/queue.py
@@ -3,13 +3,13 @@ from kafka import KafkaProducer, KafkaConsumer
 from smart_getenv import getenv
 import logging
 
-import datetime
+from .ext import Topic
 
 logger = logging.getLogger(__name__)
 
 
-class Queue:
-    def __init__(self, name, testing=False):
+class Queue(Topic):
+    def __init__(self, name, testing=False, security_protocol="SSL"):
         self.name = name
         self.testing = testing
         mode = "testing" if self.testing else "live"
@@ -20,61 +20,34 @@ class Queue:
             bootstrap_servers = getenv(
                 "KAFKA_BOOTSTRAP_SERVERS", type=list, separator=","
             )
+            self._args = {"bootstrap_servers": bootstrap_servers}
+
+            if security_protocol:
+                self._args.update(
+                    {
+                        "ssl_cafile": getenv("KAFKA_SSL_CAFILE"),
+                        "ssl_certfile": getenv("KAFKA_SSL_CERTFILE"),
+                        "ssl_keyfile": getenv("KAFKA_SSL_KEYFILE"),
+                        "security_protocol": "SSL",
+                    }
+                )
 
             logger.debug(f"bootstrap servers: {bootstrap_servers}")
 
             self._producer = KafkaProducer(
-                bootstrap_servers=bootstrap_servers,
-                value_serializer=msgpack.dumps,
+                value_serializer=msgpack.dumps, **self._args
             )
 
             self._consumer = KafkaConsumer(
                 self.name,
                 group_id=getenv("KIRBY_SUPERVISOR_GROUP_ID", type=str),
                 enable_auto_commit=True,
-                bootstrap_servers=bootstrap_servers,
                 value_deserializer=msgpack.loads,
+                **self._args,
             )
 
-    def append(self, message, submitted=None):
-        if submitted is None:
-            submitted = datetime.datetime.utcnow()
-
-        if self.testing:
-            self._messages.append((submitted, message))
-
-        else:
-            timestamp_ms = int(submitted.timestamp() * 1000)
-            self._producer.send(self.name, message, timestamp_ms=timestamp_ms)
-            self._producer.flush()
-
-    def between(self, start, end):
-        if self.testing:
-            return [msg for t, msg in self._messages if start <= t < end]
-        else:
-            self._consumer.poll(timeout_ms=5000)
-
-            partitions = self._consumer.assignment()
-
-            start_mapping = {p: start.timestamp() for p in partitions}
-            start_offsets = self._consumer.offsets_for_times(start_mapping)
-
-            start_timestamp = start.timestamp() * 1000
-            end_timestamp = end.timestamp() * 1000
-
-            messages = []
-            for partition, offsets in start_offsets.items():
-                self._consumer.seek(partition=partition, offset=offsets.offset)
-
-            records_by_partition = self._consumer.poll(timeout_ms=5000)
-
-            for partition, records in records_by_partition.items():
-                for record in records:
-                    if start_timestamp <= record.timestamp < end_timestamp:
-                        messages.append((record.timestamp, record.value))
-
-            messages.sort(key=lambda x: x[0])
-            return [v for t, v in messages]
+    def append(self, *args, **kargs):
+        super().send(*args, **kargs)
 
     def last(self):
         if self.testing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ redis==3.2.1
 requests_flask_adapter==0.0.1
 smart-getenv==1.1.0
 SQLAlchemy==1.3.3
+tenacity==5.0.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,6 +291,5 @@ def kafka_topic_factory():
     else:
         logger.warning(
             f"There is no KAFKA_BOOTSTRAP_SERVERS. "
-            f"Creation of kafka_topic passed."
+            f"Creation of kafka_topic skipped."
         )
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,26 +250,47 @@ def kafka_topic_factory():
     from kafka import KafkaAdminClient
     from kafka.admin import NewTopic
     from kafka.errors import UnknownTopicOrPartitionError
+    import logging
+
+    logger = logging.getLogger(__name__)
 
     load_dotenv()
 
     bootstrap_servers = getenv(
         "KAFKA_BOOTSTRAP_SERVERS", type=list, separator=","
     )
+    if bootstrap_servers:
+        security_protocol = getenv("KAFKA_SECURITY_PROTOCOL")
+        if security_protocol == "SSL":
+            args = {
+                "security_protocol": security_protocol,
+                "ssl_cafile": getenv("KAFKA_SSL_CAFILE"),
+                "ssl_certfile": getenv("KAFKA_SSL_CERTFILE"),
+                "ssl_keyfile": getenv("KAFKA_SSL_KEYFILE"),
+            }
+        else:
+            args = {}
 
-    admin = KafkaAdminClient(bootstrap_servers=bootstrap_servers)
+        admin = KafkaAdminClient(bootstrap_servers=bootstrap_servers, **args)
 
-    @contextmanager
-    def create_kafka_topic(topic_name):
-        try:
+        @contextmanager
+        def create_kafka_topic(topic_name):
+            try:
+                admin.delete_topics([topic_name])
+            except UnknownTopicOrPartitionError:
+                pass
+
+            admin.create_topics([NewTopic(topic_name, 1, 1)], timeout_ms=1500)
+            yield
+
             admin.delete_topics([topic_name])
-        except UnknownTopicOrPartitionError:
-            pass
+            admin.close()
 
-        admin.create_topics([NewTopic(topic_name, 1, 1)], timeout_ms=1500)
-        yield
+        return create_kafka_topic
 
-        admin.delete_topics([topic_name])
-        admin.close()
+    else:
+        logger.warning(
+            f"There is no KAFKA_BOOTSTRAP_SERVERS. "
+            f"Creation of kafka_topic passed."
+        )
 
-    return create_kafka_topic

--- a/tests/tests_api/conftest.py
+++ b/tests/tests_api/conftest.py
@@ -57,14 +57,12 @@ def kirby_topic(kirby_app, kafka_topic_factory):
     )
     if bootstrap_servers:
         with kafka_topic_factory(TOPIC_NAME):
-            topic = Topic(kirby_app, "TOPIC_NAME")
-            yield topic
-        topic.close()
+            with Topic(kirby_app, "TOPIC_NAME") as topic:
+                yield topic
     else:
         logger.warning(
             f"There is no KAFKA_BOOTSTRAP_SERVERS. "
             f"Topic will be created in testing mode"
         )
-        topic = Topic(kirby_app, "TOPIC_NAME", testing=True)
-        yield topic
-        topic.close()
+        with Topic(kirby_app, "TOPIC_NAME", testing=True) as topic:
+            yield topic

--- a/tests/tests_api/test_api.py
+++ b/tests/tests_api/test_api.py
@@ -41,7 +41,7 @@ def test_it_add_source(
     script_in_db = get_script_in_db_from_id(kirby_app.ctx.ID)
 
     assert script_in_db.sources[0] == get_topic_in_db_from_name(
-        kirby_topic.topic_name
+        kirby_topic.name
     )
 
 
@@ -58,7 +58,7 @@ def test_it_add_destination(
     script_in_db = get_script_in_db_from_id(kirby_app.ctx.ID)
 
     assert script_in_db.destinations[0] == get_topic_in_db_from_name(
-        kirby_topic.topic_name
+        kirby_topic.name
     )
 
 

--- a/tests/tests_api/test_api_ext.py
+++ b/tests/tests_api/test_api_ext.py
@@ -1,12 +1,3 @@
-import os
-import pytest
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    not os.getenv("KAFKA_BOOTSTRAP_SERVERS"),
-    reason="missing KAFKA_BOOTSTRAP_SERVERS environment",
-)
 def test_it_creates_a_kirby_topic(kirby_topic):
     assert not kirby_topic.next()
 


### PR DESCRIPTION
Also adding a retry decorator to handle Kafka errors.
Can also execute tests with a running Kafka instance if a env var named KAFKA_BOOTSTRAP_SERVERS is found.