### PR TITLE
Add ConfigException and check that a database URI is specified.

### DIFF
--- a/kirby/exc.py
+++ b/kirby/exc.py
@@ -4,3 +4,11 @@ class CoolDownException(Exception):
     """
 
     pass
+
+
+class ConfigException(Exception):
+    """
+        Configuration is incomplete.
+    """
+
+    pass

--- a/kirby/exc.py
+++ b/kirby/exc.py
@@ -7,8 +7,4 @@ class CoolDownException(Exception):
 
 
 class ConfigException(Exception):
-    """
-        Configuration is incomplete.
-    """
-
     pass

--- a/kirby/web/__init__.py
+++ b/kirby/web/__init__.py
@@ -5,6 +5,7 @@ from smart_getenv import getenv
 from .admin import admin
 from .endpoints import api
 from .forms import LoginForm
+from ..exc import ConfigException
 from ..models import db
 from ..models.security import user_datastore, security, UserRoles
 
@@ -22,6 +23,9 @@ def app_maker(config=None):
 
     if config:  # pragma: no cover
         app.config.update(config)
+
+    if not app.config.get("SQLALCHEMY_DATABASE_URI"):
+        raise ConfigException("Database is not defined. Please specify 'SQLALCHEMY_DATABASE_URI'")
 
     db.init_app(app)
     admin.init_app(app)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ from pytest import raises
 from datetime import datetime
 
 from dateutil.parser import parse
+from kirby.exc import ConfigException
 from kirby.models import (
     db,
     Job,
@@ -16,6 +17,15 @@ from kirby.models import (
     ConfigKey,
     ConfigScope,
 )
+from kirby.web import app_maker
+
+
+def test_database_config_exception():
+    with raises(ConfigException):
+        app_maker(config={
+            "TESTING": True,
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        })
 
 
 def test_it_creates_a_job(webapp):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,6 +21,10 @@ from kirby.web import app_maker
 
 
 def test_database_config_exception():
+    """
+    Test that a ConfigException is returned when the SQLALCHEMY_DATABASE_URI
+    config variable is not defined.
+    """
     with raises(ConfigException):
         app_maker(config={
             "TESTING": True,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,11 +20,7 @@ from kirby.models import (
 from kirby.web import app_maker
 
 
-def test_database_config_exception():
-    """
-    Test that a ConfigException is returned when the SQLALCHEMY_DATABASE_URI
-    config variable is not defined.
-    """
+def test_exception_is_raised_when_db_config_is_missing():
     with raises(ConfigException):
         app_maker(config={
             "TESTING": True,


### PR DESCRIPTION
Running the application without a database defined returns a cryptic stack trace. It should be clear for the user that the "SQLALCHEMY_DATABASE_URI" variable should be defined.